### PR TITLE
Change the href to officeapps to use same protocol as this page

### DIFF
--- a/ckanext/officedocs/templates/officedocs/preview.html
+++ b/ckanext/officedocs/templates/officedocs/preview.html
@@ -1,5 +1,5 @@
 <button id="fullscreeniframe" class="btn" style="position:absolute; right:5px; top:20px">Fullscreen</button>
-<iframe id="cvframe" src="http://view.officeapps.live.com/op/view.aspx?src={{resource_url}}" frameborder="0" allowfullscreen="" width="100%" height="400px"></iframe>
+<iframe id="cvframe" src="//view.officeapps.live.com/op/view.aspx?src={{resource_url}}" frameborder="0" allowfullscreen="" width="100%" height="400px"></iframe>
 <script>
 // http://stackoverflow.com/questions/18901847/iframe-enter-fullscreen-mode
 (function(window, document){


### PR DESCRIPTION
Rather than choosing http or https as a default, using // should just use the same protocol as the page that is loading.  

If it is on a site with https, it'll use https. 
If it is on a site with http, it'll use http.