### PR TITLE
fix: on install it tries to open the old rst file

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from os import path
 here = path.abspath(path.dirname(__file__))
 
 # Get the long description from the relevant file
-with open(path.join(here, 'README.rst'), encoding='utf-8') as f:
+with open(path.join(here, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 setup(


### PR DESCRIPTION
This patches the issue of install trying to open `README.rst` instead of the `README.md`