### PR TITLE
Add configurable supported formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,23 @@ IResourceView
 
 ## Supported formats
 
-This plugin will attempt to preview the following formats
+By default, this plugin will attempt to preview the following formats:
 
 > \"DOC\", \"DOCX\", \"XLS\", \"XLSX\", \"XLSB\", \"PPT\", \"PPTX\", \"PPS\",
 > \"PPSX\", \"ODT\", \"ODS\", \"ODP\"
+
+The supported formats can be configured in your CKAN configuration file:
+
+```ini
+ckanext.officedocs.supported_formats = DOC DOCX XLS XLSX XLSB PPT PPTX PPS PPSX ODT ODS ODP
+```
+
+Formats are separated by spaces and matched case-insensitively. For example,
+to add macro-enabled Microsoft Office formats:
+
+```ini
+ckanext.officedocs.supported_formats = DOC DOCX DOCM XLS XLSX XLSM XLSB PPT PPTX PPTM PPS PPSX PPSM ODT ODS ODP
+```
 
 ## Installation
 

--- a/ckanext/officedocs/plugin.py
+++ b/ckanext/officedocs/plugin.py
@@ -5,6 +5,22 @@ import ckan.plugins.toolkit as tk
 from six.moves.urllib.parse import quote_plus
 
 
+SUPPORTED_FORMATS_CONFIG = "ckanext.officedocs.supported_formats"
+DEFAULT_SUPPORTED_FORMATS = (
+    "DOC DOCX XLS XLSX XLSB PPT PPTX PPS PPSX ODT ODS ODP"
+)
+
+
+def get_supported_formats():
+    value = tk.config.get(
+        SUPPORTED_FORMATS_CONFIG, DEFAULT_SUPPORTED_FORMATS
+    )
+    return [
+        format_.upper()
+        for format_ in tk.aslist(value)
+    ]
+
+
 class OfficeDocsPlugin(p.SingletonPlugin):
     p.implements(p.IConfigurer)
     p.implements(p.IResourceView)
@@ -33,16 +49,11 @@ class OfficeDocsPlugin(p.SingletonPlugin):
         }
 
     def can_view(self, data_dict):
-        supported_formats = [
-            "DOC", "DOCX", "XLS",
-            "XLSX", "XLSB", "PPT", "PPTX",
-            "PPS", "PPSX", "ODT", "ODS", "ODP"
-        ]
         try:
             pkg_private = data_dict.get("package",{}).get("private", False)
             if not pkg_private:
                 res = data_dict.get("resource",{}).get("format", "").upper()
-                return res in supported_formats
+                return res in get_supported_formats()
             else:
                 return False
         except Exception:

--- a/ckanext/officedocs/tests/test_view.py
+++ b/ckanext/officedocs/tests/test_view.py
@@ -1,6 +1,12 @@
 import ckan.plugins as p
 from ckan.tests import factories
 
+from ckanext.officedocs.plugin import (
+    OfficeDocsPlugin,
+    SUPPORTED_FORMATS_CONFIG,
+)
+
+
 def test_view_on_resource_page():
     sysadmin = factories.Sysadmin()
     dataset = factories.Dataset()
@@ -22,3 +28,34 @@ def test_view_on_resource_page():
 
     assert response.get('title') == 'Preview'
     assert response.get('view_type') == 'officedocs_view'
+
+
+def test_can_view_uses_default_supported_formats(monkeypatch, ckan_config):
+    monkeypatch.delitem(
+        ckan_config, SUPPORTED_FORMATS_CONFIG, raising=False
+    )
+
+    assert OfficeDocsPlugin().can_view({
+        "package": {"private": False},
+        "resource": {"format": "docx"},
+    })
+
+
+def test_can_view_uses_configured_supported_formats(
+    monkeypatch, ckan_config
+):
+    monkeypatch.setitem(
+        ckan_config,
+        SUPPORTED_FORMATS_CONFIG,
+        "docm xlsm PPTM ppsm",
+    )
+    plugin = OfficeDocsPlugin()
+
+    assert plugin.can_view({
+        "package": {"private": False},
+        "resource": {"format": "DoCm"},
+    })
+    assert not plugin.can_view({
+        "package": {"private": False},
+        "resource": {"format": "DOCX"},
+    })


### PR DESCRIPTION
### Proposed changes

The Office Online viewer supports more document formats than the extension
currently exposes through its hardcoded supported formats list.

- Add the `ckanext.officedocs.supported_formats` configuration option.
- Preserve the existing supported formats when the option is not configured.
- Parse formats using CKAN's standard list handling and match them
  case-insensitively.
- Document how to enable additional formats such as `DOCM`, `XLSM`, `PPTM`,
  and `PPSM`.
- Add tests for the default and configured format lists.