### PR TITLE
Modernize for Python 3, add config declaration, CI & polish (v2.0.0)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,28 @@
+name: Publish to PyPI
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  build-and-publish:
+    name: Build and publish to PyPI
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/project/ckanext-officedocs/
+    permissions:
+      # Required for PyPI Trusted Publishing (OIDC). No API token needed.
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+      - name: Build sdist and wheel
+        run: |
+          python -m pip install --upgrade build
+          python -m build
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,56 @@
+name: Tests
+on: [push, pull_request]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+      - name: Install requirements
+        run: pip install flake8
+      - name: Check syntax
+        run: flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+
+  test:
+    needs: lint
+    strategy:
+      fail-fast: false
+      matrix:
+        ckan-version: ["2.10", "2.11"]
+    name: CKAN ${{ matrix.ckan-version }}
+    runs-on: ubuntu-latest
+    container:
+      image: ckan/ckan-dev:${{ matrix.ckan-version }}
+    services:
+      solr:
+        image: ckan/ckan-solr:${{ matrix.ckan-version }}-solr9
+      postgres:
+        image: ckan/ckan-postgres-dev:${{ matrix.ckan-version }}
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: postgres
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+      redis:
+        image: redis:3
+    env:
+      CKAN_SQLALCHEMY_URL: postgresql://ckan_default:pass@postgres/ckan_test
+      CKAN_DATASTORE_WRITE_URL: postgresql://datastore_write:pass@postgres/datastore_test
+      CKAN_DATASTORE_READ_URL: postgresql://datastore_read:pass@postgres/datastore_test
+      CKAN_SOLR_URL: http://solr:8983/solr/ckan
+      CKAN_REDIS_URL: redis://redis:6379/1
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install extension and test requirements
+        run: |
+          pip install -e .
+          pip install -r dev-requirements.txt
+          # Point test.ini at the CKAN core test config shipped in the container.
+          sed -i -e 's/use = config:.*/use = config:\/srv\/app\/src\/ckan\/test-core.ini/' test.ini
+      - name: Setup database
+        run: ckan -c test.ini db init
+      - name: Run tests
+        run: pytest --ckan-ini=test.ini --cov=ckanext.officedocs --disable-warnings ckanext/officedocs

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,6 +24,9 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: ckan/ckan-dev:${{ matrix.ckan-version }}
+      # Run as root so actions/checkout can write to the runner's file-command
+      # dir; the ckan-dev:2.11 image otherwise runs as a non-root user (EACCES).
+      options: --user root
     services:
       solr:
         image: ckan/ckan-solr:${{ matrix.ckan-version }}-solr9

--- a/.serena/memories/conventions.md
+++ b/.serena/memories/conventions.md
@@ -1,19 +1,27 @@
 # Conventions
 
-## Config flags (module-level in plugin.py, read via tk.config.get + fallback)
-- `ckanext.officedocs.supported_formats` — space-separated, matched
-  case-insensitively, uppercased on read. Helper `get_supported_formats()`,
-  default `DEFAULT_SUPPORTED_FORMATS`.
-- `ckanext.officedocs.enable_private_fallback` — bool (default False, read via
-  `tk.asbool`). Helper `private_fallback_enabled()`. Opt-in; when off, private
-  packages get no view (preserves legacy behavior).
-- Pattern for any new flag: `<CONST>_CONFIG` name + `DEFAULT_<NAME>` + a small
-  reader helper mirroring the above.
+## Config flags
+Three options, each with a module-level `<NAME>_CONFIG` constant + `DEFAULT_<NAME>`
++ a reader helper in `plugin.py`, AND a declaration entry in
+`ckanext/officedocs/config_declaration.yaml` (loaded via the
+`@tk.blanket.config_declarations` decorator on the plugin class):
+- `ckanext.officedocs.supported_formats` — space-separated, case-insensitive,
+  uppercased on read. Helper `get_supported_formats()`.
+- `ckanext.officedocs.enable_private_fallback` — bool (default False). Helper
+  `private_fallback_enabled()`. Opt-in; off → private packages get no view.
+- `ckanext.officedocs.iframe_height` — CSS length (default "400px"). Helper
+  `get_iframe_height()`; passed to preview.html for the public iframe.
+- Helpers keep an inline `tk.config.get(KEY, DEFAULT)` fallback ON PURPOSE: unit
+  tests instantiate the plugin directly without loading the declaration, so the
+  inline default must still apply. Don't remove it.
+- Pattern for a new flag: constant + DEFAULT + helper + yaml entry.
 
-## Format-list sync rule
-When changing the default supported formats, update in sync:
-1. `DEFAULT_SUPPORTED_FORMATS` in `plugin.py`
-2. the two format lists in `README.md`.
+## Default-value sync rule
+A default lives in several places that must stay consistent:
+- supported_formats default: `DEFAULT_SUPPORTED_FORMATS` (plugin.py),
+  `config_declaration.yaml`, and the README (intro example lists + the
+  "Configuration reference" table). Keep all in sync when changing it.
+- Other defaults: the `DEFAULT_*` constant, the yaml, and the README table.
 
 ## Private-package fallback (preview.html private branch)
 - MS viewer can't reach private resources; the logged-in user's own browser can.
@@ -21,15 +29,18 @@ When changing the default supported formats, update in sync:
   so NO auto-render / no install detection — best-effort only.
 - JS UA-detects Chromium (prefer `navigator.userAgentData.brands` containing
   "Chromium"; fallback UA-string check for Chrome/Chromium/Edg/OPR, excluding
-  Firefox). Chromium → "Open document" link (target=_blank top-level nav, which an
-  installed extension can render) + extension install tips. Non-Chromium →
-  explanatory message. Default-visible block is the non-Chromium one (degrades
-  without JS).
+  Firefox). Chromium → "Open document" link (target=_blank top-level nav) +
+  install tips. Non-Chromium → explanatory message. Default-visible block is the
+  non-Chromium one (degrades without JS).
+- User-facing template strings are wrapped in `{{ _(...) }}` for i18n.
 
 ## Style
-- 2/3-compatible; import cross-version helpers from `six`.
+- Python 3 only (CKAN 2.10/2.11). `urllib.parse` (NOT six — six was removed in
+  2.0.0). `python_requires>=3.8`.
 - `tk` = `ckan.plugins.toolkit`, `p` = `ckan.plugins`.
 - `info()` sets `always_available: False` (no auto-create), `iframed: False`
   (template manages its own iframe).
-- Tests use `monkeypatch` + the `ckan_config` fixture to set/delete config keys;
-  assert `can_view()` directly with hand-built data_dicts.
+- `setup_template_variables` uses defensive `.get()` (never index data_dict).
+- Tests use `monkeypatch` + `ckan_config` fixture to set/delete config keys;
+  assert `can_view()` / `setup_template_variables()` directly with hand-built
+  data_dicts (see `mem:tests`-style cases in tests/test_view.py).

--- a/.serena/memories/core.md
+++ b/.serena/memories/core.md
@@ -7,15 +7,22 @@ Microsoft's hosted Office Web Viewer in an iframe. No runtime deps of its own.
 ## Source map
 - `ckanext/officedocs/plugin.py` — the entire plugin (`OfficeDocsPlugin` +
   module-level config helpers). Everything of interest lives here.
+- `ckanext/officedocs/config_declaration.yaml` — CKAN config declaration for the
+  three options (loaded via `@tk.blanket.config_declarations` on the plugin).
 - `ckanext/officedocs/templates/officedocs/preview.html` — iframe + fullscreen JS
-  (public branch) and private-package fallback panel (private branch).
+  (public branch) and private-package fallback panel (private branch); strings
+  are i18n-wrapped.
 - `ckanext/officedocs/templates/officedocs/form.html` — intentionally empty (no
   view config options).
 - `ckanext/officedocs/tests/test_view.py` — pytest, CKAN factories + `ckan_config`.
 - `ckanext/officedocs/{fanstatic,public}/` — empty placeholders (only .gitignore);
   all JS is inlined in templates despite `tk.add_resource("fanstatic", ...)`.
-- `setup.py` — declares entry point `officedocs_view=...plugin:OfficeDocsPlugin`
-  under `[ckan.plugins]`; bump `version` for releases.
+- `setup.py` — entry point `officedocs_view=...plugin:OfficeDocsPlugin` under
+  `[ckan.plugins]`; bump `version` for releases.
+- `test.ini` — CKAN test config (`use = config:../ckan/test-core.ini`); CI
+  rewrites that path to the container's core test ini.
+- `.github/workflows/` — `test.yml` (lint + CKAN matrix) and `publish.yml`
+  (PyPI Trusted Publishing on `v*` tag). See `mem:tech_stack`.
 
 ## Invariants
 - `can_view()` is the gate: format must be in supported list (always), AND
@@ -25,13 +32,14 @@ Microsoft's hosted Office Web Viewer in an iframe. No runtime deps of its own.
 - Private packages can't use MS's viewer (it fetches a public URL it can't
   reach). Private branch instead shows a client-side fallback; see `mem:conventions`.
 - `setup_template_variables()` passes `resource_url` (quote_plus-encoded, for the
-  MS viewer query param) AND `resource_download_url` (raw, for the fallback link).
-  Preserve the quote_plus on `resource_url`.
+  MS viewer query param), `resource_download_url` (raw, for the fallback link),
+  and `iframe_height`. Preserve the quote_plus on `resource_url`. Uses defensive
+  `.get()` on data_dict.
 
 ## Further reading
-- Stack & versions: `mem:tech_stack`
+- Stack & versions, CI/release: `mem:tech_stack`
 - Commands to run (dev/test): `mem:suggested_commands`
-- Code conventions, config flags, format-sync rule: `mem:conventions`
+- Code conventions, config flags, default-sync rule: `mem:conventions`
 - What to run when a task is done: `mem:task_completion`
 
 Note: a project `CLAUDE.md` (repo root) documents the same architecture in prose.

--- a/.serena/memories/task_completion.md
+++ b/.serena/memories/task_completion.md
@@ -1,11 +1,24 @@
 # Task Completion
 
-No lint/format/type-check tooling is configured in-repo. After a code change:
+After a code change:
 
 1. Run the test suite in an activated CKAN virtualenv:
    `pytest --ckan-ini=<test.ini> ckanext/officedocs/tests`
    (see `mem:suggested_commands` for the test.ini caveat).
-2. If default supported formats changed, verify the format-list sync rule in
-   `mem:conventions` (plugin.py + two README lists).
-3. Template/JS changes can't be unit-tested here — verify manually in-browser
+2. Lint matches CI: `flake8 . --select=E9,F63,F7,F82` (CI's `test.yml` lint job
+   fails the build on these).
+3. If any config default changed, apply the default-sync rule in
+   `mem:conventions` (constant + config_declaration.yaml + README).
+4. If touching packaged data (templates, yaml), confirm it ships in the wheel:
+   `python -m build && unzip -l dist/*.whl | grep <file>` (MANIFEST.in governs
+   inclusion; `*.yaml` must stay listed).
+5. `python -m build && python -m twine check dist/*` should PASS with no warnings.
+6. Template/JS changes can't be unit-tested here — verify manually in-browser
    (public iframe path; private fallback in Chromium vs non-Chromium).
+
+## Release (see git history for the established flow)
+Bump `setup.py` version, commit, push master, annotated `vX.Y.Z` tag, GitHub
+release with contributor credits (mirror prior releases' "What's Changed" /
+"New Contributors" format). Pushing a `v*` tag triggers `publish.yml` →
+PyPI Trusted Publishing (no token needed once the PyPI trusted publisher is set
+up for the repo).

--- a/.serena/memories/tech_stack.md
+++ b/.serena/memories/tech_stack.md
@@ -1,12 +1,20 @@
 # Tech Stack
 
-- Language: Python; declares support for both 2.7 and 3.8 (keep new code 2/3
-  compatible — `six` is used, esp. `six.moves.urllib.parse.quote_plus`).
-- Framework: CKAN 2.10 extension. Uses `ckan.plugins` (`p`) and
+- Language: Python 3 only (CKAN 2.10/2.11). `python_requires>=3.8`. NOTE: six and
+  Python 2 support were removed in 2.0.0 — use stdlib `urllib.parse`.
+- Framework: CKAN extension. Uses `ckan.plugins` (`p`) and
   `ckan.plugins.toolkit` (aliased `tk`) for config, `aslist`, `asbool`,
-  translations (`tk._`), template/resource registration.
-- Packaging: setuptools (`setup.py`, find_packages). Plugin discovered via the
-  `[ckan.plugins]` entry point.
-- Dev dep: `six>=1.10.0` (`dev-requirements.txt`).
-- Not runnable standalone — requires a working CKAN install + its test harness.
-- No lint/format/type-check tooling configured in-repo.
+  translations (`tk._`), template/resource registration, and
+  `tk.blanket.config_declarations`.
+- Config: declared in `ckanext/officedocs/config_declaration.yaml` (schema
+  version 1), wired by the `@tk.blanket.config_declarations` class decorator.
+- Packaging: setuptools (`setup.py`). `long_description_content_type=text/markdown`.
+  Entry point `officedocs_view` under `[ckan.plugins]`. MANIFEST.in must keep
+  `*.yaml` in the recursive-include so the config declaration ships in the wheel.
+- CI: GitHub Actions in `.github/workflows/` — `test.yml` (flake8 lint +
+  CKAN 2.10/2.11 matrix using ckan/ckan-dev containers + solr/postgres/redis;
+  uses `test.ini`) and `publish.yml` (build + PyPI Trusted Publishing on `v*`
+  tag push; needs a PyPI trusted-publisher configured for the repo).
+- Dev dep: `pytest-cov` (`dev-requirements.txt`); pytest/factories come from
+  CKAN's own dev-requirements.
+- Not runnable standalone — needs a working CKAN install + its test harness.

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,2 @@
 include README.md
-recursive-include ckanext/officedocs *.html *.json *.js *.less *.css
+recursive-include ckanext/officedocs *.html *.json *.js *.less *.css *.yaml

--- a/README.md
+++ b/README.md
@@ -52,6 +52,29 @@ Note: browser extensions cannot be detected from a web page, so the fallback
 always shows the tip/link rather than auto-detecting whether an extension is
 present.
 
+## Viewer height
+
+The height of the Office viewer iframe (used for public resources) is
+configurable:
+
+```ini
+ckanext.officedocs.iframe_height = 400px
+```
+
+Any valid CSS length is accepted (e.g. `600px`, `75vh`). Defaults to `400px`.
+
+## Configuration reference
+
+All options are declared via CKAN's config declaration, so you can inspect
+them with `ckan config declaration officedocs` and validate your config with
+`ckan config validate`.
+
+| Option | Default | Description |
+| --- | --- | --- |
+| `ckanext.officedocs.supported_formats` | `DOC DOCX XLS XLSX XLSB PPT PPTX PPS PPSX ODT ODS ODP` | Space-separated formats to preview (case-insensitive). |
+| `ckanext.officedocs.enable_private_fallback` | `false` | Enable the Chromium fallback preview for private resources. |
+| `ckanext.officedocs.iframe_height` | `400px` | CSS height of the public-resource viewer iframe. |
+
 ## Installation
 
 To install ckanext-officedocs:

--- a/ckanext/officedocs/config_declaration.yaml
+++ b/ckanext/officedocs/config_declaration.yaml
@@ -1,0 +1,26 @@
+version: 1
+groups:
+  - annotation: ckanext-officedocs settings
+    options:
+      - key: ckanext.officedocs.supported_formats
+        default: DOC DOCX XLS XLSX XLSB PPT PPTX PPS PPSX ODT ODS ODP
+        description: |
+          Space-separated list of resource formats (matched case-insensitively)
+          that the Office previewer will offer to render.
+        type: str
+
+      - key: ckanext.officedocs.enable_private_fallback
+        default: false
+        description: |
+          Offer a client-side fallback preview for resources in private
+          datasets. Microsoft's online viewer cannot reach private resources;
+          when enabled, Chromium-based browsers are shown an "Open document"
+          link plus a tip to install an Office viewer extension.
+        type: bool
+
+      - key: ckanext.officedocs.iframe_height
+        default: 400px
+        description: |
+          CSS height of the Office viewer iframe used for public resources
+          (e.g. "400px", "60vh").
+        type: str

--- a/ckanext/officedocs/config_declaration.yaml
+++ b/ckanext/officedocs/config_declaration.yaml
@@ -7,7 +7,6 @@ groups:
         description: |
           Space-separated list of resource formats (matched case-insensitively)
           that the Office previewer will offer to render.
-        type: str
 
       - key: ckanext.officedocs.enable_private_fallback
         default: false
@@ -23,4 +22,3 @@ groups:
         description: |
           CSS height of the Office viewer iframe used for public resources
           (e.g. "400px", "60vh").
-        type: str

--- a/ckanext/officedocs/plugin.py
+++ b/ckanext/officedocs/plugin.py
@@ -1,8 +1,7 @@
-import ckan.lib.helpers as h
 import ckan.plugins as p
 import ckan.plugins.toolkit as tk
 
-from six.moves.urllib.parse import quote_plus
+from urllib.parse import quote_plus
 
 
 SUPPORTED_FORMATS_CONFIG = "ckanext.officedocs.supported_formats"
@@ -12,6 +11,9 @@ DEFAULT_SUPPORTED_FORMATS = (
 
 PRIVATE_FALLBACK_CONFIG = "ckanext.officedocs.enable_private_fallback"
 DEFAULT_PRIVATE_FALLBACK = False
+
+IFRAME_HEIGHT_CONFIG = "ckanext.officedocs.iframe_height"
+DEFAULT_IFRAME_HEIGHT = "400px"
 
 
 def get_supported_formats():
@@ -30,6 +32,11 @@ def private_fallback_enabled():
     )
 
 
+def get_iframe_height():
+    return tk.config.get(IFRAME_HEIGHT_CONFIG, DEFAULT_IFRAME_HEIGHT)
+
+
+@tk.blanket.config_declarations
 class OfficeDocsPlugin(p.SingletonPlugin):
     p.implements(p.IConfigurer)
     p.implements(p.IResourceView)
@@ -50,12 +57,14 @@ class OfficeDocsPlugin(p.SingletonPlugin):
         }
 
     def setup_template_variables(self, context, data_dict):
-        resource_url = data_dict["resource"]["url"]
-        private_package = data_dict["package"]["private"]
+        resource = data_dict.get("resource", {})
+        package = data_dict.get("package", {})
+        resource_url = resource.get("url", "")
         return {
             "resource_url": quote_plus(resource_url),
             "resource_download_url": resource_url,
-            "private_package": private_package
+            "private_package": package.get("private", False),
+            "iframe_height": get_iframe_height(),
         }
 
     def can_view(self, data_dict):

--- a/ckanext/officedocs/templates/officedocs/preview.html
+++ b/ckanext/officedocs/templates/officedocs/preview.html
@@ -1,20 +1,20 @@
 {% if private_package %}
 <div id="officedocs-private-fallback" style="text-align:center; padding:20px;">
   <div id="officedocs-chromium-fallback" style="display:none;">
-    <p>Microsoft's online viewer cannot reach private resources, but your browser can.</p>
+    <p>{{ _("Microsoft's online viewer cannot reach private resources, but your browser can.") }}</p>
     <p>
-      <a id="officedocs-open-doc" class="btn btn-primary" href="{{ resource_download_url }}" target="_blank" rel="noopener">Open document</a>
+      <a id="officedocs-open-doc" class="btn btn-primary" href="{{ resource_download_url }}" target="_blank" rel="noopener">{{ _("Open document") }}</a>
     </p>
     <p style="margin-top:10px;">
-      Tip: install a Chromium Office viewer extension to render Office files in your browser &mdash;
+      {{ _("Tip: install a Chromium Office viewer extension to render Office files in your browser:") }}
       <a href="https://chromewebstore.google.com/detail/office/ndjpnladcallmjemlbaebfadecfhkepb" target="_blank" rel="noopener">Office</a>
-      or
+      {{ _("or") }}
       <a href="https://chromewebstore.google.com/detail/office-editing-for-docs-s/gbkeegbaiigmenfmjfclcdgdpimamgkj" target="_blank" rel="noopener">Office Editing for Docs, Sheets &amp; Slides</a>.
     </p>
   </div>
   <div id="officedocs-other-fallback">
-    <p>This resource is private, so Microsoft's online viewer is unable to access and display it.</p>
-    <p>To preview private Office files, use a Chromium-based browser (Chrome, Edge, Brave, Opera) with an Office viewer extension installed.</p>
+    <p>{{ _("This resource is private, so Microsoft's online viewer is unable to access and display it.") }}</p>
+    <p>{{ _("To preview private Office files, use a Chromium-based browser (Chrome, Edge, Brave, Opera) with an Office viewer extension installed.") }}</p>
   </div>
 </div>
 <script>
@@ -35,47 +35,28 @@
 })(this, this.document);
 </script>
 {% else %}
-<button id="fullscreeniframe" class="btn" style="position:absolute; right:5px; top:20px">Fullscreen</button>
-<iframe id="cvframe" src="//view.officeapps.live.com/op/view.aspx?src={{resource_url}}" frameborder="0" allowfullscreen="" width="100%" height="400px"></iframe>
+<button id="fullscreeniframe" class="btn" style="position:absolute; right:5px; top:20px">{{ _("Fullscreen") }}</button>
+<iframe id="cvframe" src="//view.officeapps.live.com/op/view.aspx?src={{ resource_url }}" frameborder="0" allowfullscreen="" width="100%" height="{{ iframe_height }}"></iframe>
 <script>
-// http://stackoverflow.com/questions/18901847/iframe-enter-fullscreen-mode
 (function(window, document){
-        var $ = function(selector,context){return(context||document).querySelector(selector)};
+  var button = document.getElementById("fullscreeniframe");
+  var iframe = document.getElementById("cvframe");
+  if (!button || !iframe) { return; }
 
-        var iframe = $("iframe"),
-            domPrefixes = 'Webkit Moz O ms Khtml'.split(' ');
+  var requestFullscreen = iframe.requestFullscreen
+    || iframe.webkitRequestFullscreen
+    || iframe.mozRequestFullScreen
+    || iframe.msRequestFullscreen;
 
-        var fullscreen = function(elem) {
-            var prefix;
-            // Mozilla and webkit intialise fullscreen slightly differently
-            for ( var i = -1, len = domPrefixes.length; ++i < len; ) {
-              prefix = domPrefixes[i].toLowerCase();
+  if (!requestFullscreen) {
+    // Browser doesn't support fullscreen; hide the control rather than failing.
+    button.style.display = "none";
+    return;
+  }
 
-              if ( elem[prefix + 'EnterFullScreen'] ) {
-                // Webkit uses EnterFullScreen for video
-                return prefix + 'EnterFullScreen';
-                break;
-              } else if( elem[prefix + 'RequestFullScreen'] ) {
-                // Mozilla uses RequestFullScreen for all elements and webkit uses it for non video elements
-                return prefix + 'RequestFullScreen';
-                break;
-              }
-            }
-
-            return false;
-        };
-        // Webkit uses "requestFullScreen" for non video elements
-        var fullscreenother = fullscreen(document.createElement("iframe"));
-
-        if(!fullscreen) {
-            alert("Fullscreen won't work, please make sure you're using a browser that supports it and you have enabled the feature");
-            return;
-        }
-
-        $("#fullscreeniframe").addEventListener("click", function(){
-            // iframe fullscreen and non video elements in webkit use request over enter
-            iframe[fullscreenother]();
-        }, false);
-    })(this, this.document);
+  button.addEventListener("click", function(){
+    requestFullscreen.call(iframe);
+  }, false);
+})(this, this.document);
 </script>
 {% endif %}

--- a/ckanext/officedocs/templates/officedocs/preview.html
+++ b/ckanext/officedocs/templates/officedocs/preview.html
@@ -36,7 +36,7 @@
 </script>
 {% else %}
 <button id="fullscreeniframe" class="btn" style="position:absolute; right:5px; top:20px">{{ _("Fullscreen") }}</button>
-<iframe id="cvframe" src="//view.officeapps.live.com/op/view.aspx?src={{ resource_url }}" frameborder="0" allowfullscreen="" width="100%" height="{{ iframe_height }}"></iframe>
+<iframe id="cvframe" src="//view.officeapps.live.com/op/view.aspx?src={{ resource_url }}" frameborder="0" allowfullscreen="" width="100%" style="height:{{ iframe_height }};"></iframe>
 <script>
 (function(window, document){
   var button = document.getElementById("fullscreeniframe");

--- a/ckanext/officedocs/tests/test_view.py
+++ b/ckanext/officedocs/tests/test_view.py
@@ -5,6 +5,7 @@ from ckanext.officedocs.plugin import (
     OfficeDocsPlugin,
     SUPPORTED_FORMATS_CONFIG,
     PRIVATE_FALLBACK_CONFIG,
+    IFRAME_HEIGHT_CONFIG,
 )
 
 
@@ -108,3 +109,42 @@ def test_can_view_private_fallback_still_checks_format(
         "package": {"private": True},
         "resource": {"format": "pdf"},
     })
+
+
+def test_setup_template_variables_encodes_url_and_sets_flags(ckan_config):
+    result = OfficeDocsPlugin().setup_template_variables({}, {
+        "resource": {"url": "http://example.com/my doc.docx"},
+        "package": {"private": True},
+    })
+
+    assert result["resource_url"] == "http%3A%2F%2Fexample.com%2Fmy+doc.docx"
+    assert result["resource_download_url"] == "http://example.com/my doc.docx"
+    assert result["private_package"] is True
+
+
+def test_setup_template_variables_handles_missing_keys(ckan_config):
+    result = OfficeDocsPlugin().setup_template_variables({}, {})
+
+    assert result["resource_url"] == ""
+    assert result["resource_download_url"] == ""
+    assert result["private_package"] is False
+
+
+def test_setup_template_variables_iframe_height_default(
+    monkeypatch, ckan_config
+):
+    monkeypatch.delitem(ckan_config, IFRAME_HEIGHT_CONFIG, raising=False)
+
+    result = OfficeDocsPlugin().setup_template_variables({}, {})
+
+    assert result["iframe_height"] == "400px"
+
+
+def test_setup_template_variables_iframe_height_configured(
+    monkeypatch, ckan_config
+):
+    monkeypatch.setitem(ckan_config, IFRAME_HEIGHT_CONFIG, "75vh")
+
+    result = OfficeDocsPlugin().setup_template_variables({}, {})
+
+    assert result["iframe_height"] == "75vh"

--- a/ckanext/officedocs/tests/test_view.py
+++ b/ckanext/officedocs/tests/test_view.py
@@ -1,3 +1,5 @@
+import pytest
+
 import ckan.plugins as p
 from ckan.tests import factories
 
@@ -9,6 +11,8 @@ from ckanext.officedocs.plugin import (
 )
 
 
+@pytest.mark.ckan_config("ckan.plugins", "officedocs_view")
+@pytest.mark.usefixtures("with_plugins")
 def test_view_on_resource_page():
     sysadmin = factories.Sysadmin()
     dataset = factories.Dataset()

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,1 +1,3 @@
-six>=1.10.0 #pytest has requirement six>=1.10.0
+# Test dependencies. CKAN's own dev-requirements provide pytest, factory-boy,
+# pytest-ckan, etc.; list only extras specific to this extension here.
+pytest-cov

--- a/setup.py
+++ b/setup.py
@@ -14,13 +14,14 @@ setup(
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # http://packaging.python.org/en/latest/tutorial.html#version
-    version='1.2.0',
+    version='2.0.0',
 
     description='''A ResourceView that uses Microsoft's Doc preview''',
     long_description=long_description,
+    long_description_content_type='text/markdown',
 
     # The project's main homepage.
-    url='https://github.com/rossjones/ckanext-officedocs',
+    url='https://github.com/jqnatividad/ckanext-officedocs',
 
     # Author details
     author='''Ross Jones, Joel Natividad''',
@@ -40,11 +41,14 @@ setup(
         # Pick your license as you wish (should match "license" above)
         'License :: OSI Approved :: GNU Affero General Public License v3 or later (AGPLv3+)',
 
-        # Specify the Python versions you support here. In particular, ensure
-        # that you indicate whether you support Python 2, Python 3 or both.
-        'Programming Language :: Python :: 2.7',
+        # Specify the Python versions you support here.
+        'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
     ],
+
+    python_requires='>=3.8',
 
 
     # What does your project relate to?

--- a/test.ini
+++ b/test.ini
@@ -1,0 +1,40 @@
+[app:main]
+use = config:../ckan/test-core.ini
+
+# Enable this extension when running the test suite.
+ckan.plugins = officedocs_view
+
+# Logging configuration
+[loggers]
+keys = root, ckan, ckanext
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARNING
+handlers = console
+
+[logger_ckan]
+level = INFO
+handlers = console
+qualname = ckan
+propagate = 0
+
+[logger_ckanext]
+level = DEBUG
+handlers = console
+qualname = ckanext
+propagate = 0
+
+[handler_console]
+class = StreamHandler
+args = (sys.stdout,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(asctime)s %(levelname)-5.5s [%(name)s] %(message)s


### PR DESCRIPTION
## Summary

Substantial modernization pass toward a **2.0.0** release. Groups: Python 3 cleanup, CKAN 2.10 config declaration, template polish, and CI/release automation.

> **BREAKING:** drops Python 2 support (CKAN 2.10+ is Python 3 only).

## Changes

**Python 3 / packaging**
- Replace `six` with stdlib `urllib.parse`; remove unused `ckan.lib.helpers` import
- `setup.py`: `long_description_content_type='text/markdown'`, correct project `url`, `python_requires>=3.8`, drop the `Python :: 2.7` classifier (the previous `'Production/Stable :: 5'` was already fixed in 1.2.0)
- `dev-requirements.txt`: drop `six`, add `pytest-cov`

**CKAN 2.10 config declaration**
- Declare `supported_formats`, `enable_private_fallback`, and the new `iframe_height` option in `config_declaration.yaml` via `@tk.blanket.config_declarations`
- Ship `*.yaml` in `MANIFEST.in` (verified present in the built wheel)

**Polish**
- `preview.html`: i18n-wrap user-facing strings, configurable iframe height, modern Fullscreen API (drops the legacy vendor-prefix loop and the `alert()`)
- `setup_template_variables`: defensive `.get()`; passes `iframe_height`

**CI / release automation**
- `.github/workflows/test.yml`: flake8 lint + CKAN 2.10/2.11 test matrix (ckan/ckan-dev containers)
- `.github/workflows/publish.yml`: build + **PyPI Trusted Publishing** on `v*` tags
- add `test.ini`

**Tests / docs**
- New `setup_template_variables` tests (URL encoding, missing keys, iframe height default/configured)
- README "Configuration reference"; version bumped to `2.0.0`

## Reviewer notes / follow-ups
- Built locally: `python -m build` + `twine check` pass with no warnings; wheel contains the config YAML and templates; flake8 CI subset is clean.
- **Not run here:** the CKAN integration tests and the GitHub workflows (no local CKAN). The `test.yml` job may need a small first-run tweak.
- **Before tagging `v2.0.0`:** configure a PyPI Trusted Publisher for this repo (workflow `publish.yml`, environment `pypi`), or the publish job will fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)